### PR TITLE
chore: setup release action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: "@solfrenxyz/solfren-web-sdk"
+      # The logic below handles the npm publication:
+      - uses: actions/checkout@v2
+        # these if statements ensure that a publication only occurs when
+        # a new release is created:
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: "https://registry.npmjs.org"
+        if: ${{ steps.release.outputs.release_created }}
+      - run: yarn package
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Desc
稍微試了一下 [release-please-action](https://github.com/google-github-actions/release-please-action)

基本上是常駐一個 PR 在累積目前的開發進度，按下 merge 之後就會自動去打版號和 release 到 npm 上

看要不要試著先用看看

![image](https://user-images.githubusercontent.com/14068118/193887589-50bab8c1-1f83-4c61-8010-d13f078bbd1c.png)
