### PR TITLE
feat(protocols): implement simple hash

### DIFF
--- a/examples/nft.ts
+++ b/examples/nft.ts
@@ -11,6 +11,9 @@ import NFT from '../src/modules/nft';
     wonkaAPI: {
       endpoint: 'https://api.wonkalabs.xyz/v0.1/solana/mainnet/graphql',
     },
+    simpleHash: {
+      key: ''
+    }
   });
 
   const id = 'HhDDF8djnQnty2WJTxsy5VRNMutbPPd5xCtujieHBPAu'; // collection key

--- a/src/protocols/simpleHash/index.ts
+++ b/src/protocols/simpleHash/index.ts
@@ -1,0 +1,63 @@
+import got from 'got';
+import { listNftsResponse } from './response';
+
+export default class SimpleHash {
+  private endpoint: string = 'https://api.simplehash.com/api/v0';
+  private key: string;
+
+  public constructor(key: string) {
+    this.key = key;
+  }
+
+  public async nftsByWallet(walletAddress: string, cursor?: string): Promise<listNftsResponse> {
+    const url = cursor ?? `${this.endpoint}/nfts/owners?chains=solana&wallet_addresses=${walletAddress}`;
+
+    return await got({
+      method: 'get',
+      url,
+      headers: {
+        'accept': 'application/json',
+        'x-api-key': this.key,
+      }
+    }).json<listNftsResponse>();
+  }
+
+  public async nftsByCollection(id: string, cursor?: string): Promise<listNftsResponse> {
+    const collectionId = await this.lookup(id);
+    const url = cursor ?? `${this.endpoint}/nfts/collection/${collectionId}`;
+
+    return await got({
+      method: 'get',
+      url,
+      headers: {
+        'accept': 'application/json',
+        'x-api-key': this.key,
+      }
+    }).json<listNftsResponse>();
+  }
+
+  /**
+   * Lookup collection id of SimpleHash.
+   * @param id
+   * @returns string
+   */
+  private async lookup(id: string): Promise<string> {
+    const resp = await got({
+      method: 'get',
+      url: `${this.endpoint}/nfts/collections?metaplex_mint=${id}`,
+      headers: {
+        'accept': 'application/json',
+        'x-api-key': this.key,
+      }
+    }).json<{
+      collections: {
+        id: string;
+        name?: string;
+        description?: string;
+        chain: string;
+      }[]
+    }>();
+
+    return resp.collections[0].id;
+  }
+}

--- a/src/protocols/simpleHash/response.ts
+++ b/src/protocols/simpleHash/response.ts
@@ -1,0 +1,6 @@
+import { Nft } from "./types";
+
+export interface listNftsResponse {
+  nfts: Nft[];
+  next?: string;
+}

--- a/src/protocols/simpleHash/types.ts
+++ b/src/protocols/simpleHash/types.ts
@@ -1,0 +1,109 @@
+export interface Previews {
+  image_small_url: string;
+  image_medium_url: string;
+  image_large_url: string;
+  image_opengraph_url: string;
+  blurhash: string;
+}
+
+export interface Owner {
+  owner_address: string;
+  quantity: number;
+  first_acquired_date: Date;
+  last_acquired_date: Date;
+}
+
+export interface Contract {
+  type: string;
+  name: string;
+  symbol: string;
+}
+
+export interface MarketplacePage {
+  marketplace_id: string;
+  marketplace_name: string;
+  marketplace_collection_id: string;
+  nft_url: string;
+  collection_url: string;
+  verified: boolean;
+}
+
+export interface Collection {
+  collection_id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  banner_image_url: string;
+  external_url: string;
+  twitter_username: string;
+  discord_url: string;
+  marketplace_pages: MarketplacePage[];
+  metaplex_mint?: any;
+  metaplex_first_verified_creator?: any;
+  floor_prices: any[];
+  distinct_owner_count: number;
+}
+
+export interface Attribute {
+  key: string;
+  trait_type: string;
+  value: string;
+}
+
+export interface ExtraMetadata {
+  attributes: Attribute[];
+  image_original_url: string;
+  animation_original_url: string;
+  is_mutable: boolean;
+  seller_fee_basis_points: number;
+  creators: {
+    address: string;
+    verified: boolean;
+    share: number;
+  }[]
+}
+
+export interface LastSale {
+  from_address: string;
+  to_address: string;
+  quantity: number;
+  timestamp: string;
+  transaction: string;
+  marketplace_id: string;
+  marketplace_name: string;
+  is_bundle_sale: boolean;
+  payment_token: {
+    payment_token_id: string;
+    name: string;
+    symbol: string;
+    address: string | null;
+    decimals: number;
+  }
+  unit_price: number;
+  total_price: number;
+}
+
+export interface Nft {
+  nft_id: string;
+  chain: string;
+  contract_address: string;
+  token_id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  video_url: string;
+  audio_url?: any;
+  model_url?: any;
+  previews: Previews;
+  background_color?: any;
+  external_url: string;
+  created_date: Date;
+  status: string;
+  token_count: number;
+  owner_count: number;
+  owners: Owner[];
+  last_sale?: LastSale;
+  contract: Contract;
+  collection: Collection;
+  extra_metadata: ExtraMetadata;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,7 @@ export interface Config {
   cyberConnect?: {
     endpoint: string
   }
+  simpleHash?: {
+    key: string
+  }
 }


### PR DESCRIPTION
用 SimpleHash 取代 Wonka，主要用到這三支 API

- [NFTs by Collection](https://simplehash.readme.io/reference/nfts-by-collection)
- [NFTs by Wallet(s)](https://simplehash.readme.io/reference/nfts-by-owners)
- [Collection ID Lookup](https://simplehash.readme.io/reference/nft-collections)

### Ref

https://simplehash.readme.io/reference/overview